### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add your magic here!
 Run the shell script to start Embabel under Spring Shell:
 
 ```bash
-./shell.sh
+/scripts/shell.sh
 ```
 There is a single example agent, `WriteAndReviewAgent`. 
 It will be under your package name.


### PR DESCRIPTION
This pull request updates the `README.md` file to correct the path for starting Embabel under Spring Shell.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30): Updated the shell script path from `./shell.sh` to `/scripts/shell.sh` to reflect the correct location.