### PR TITLE
Default to Agent Shell on startup.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,3 @@
 # Shell scripts
 
 - `shell.sh` runs the application in interactive shell mode.
-- `mcp_server.sh` runs an MCP server that will expose MCP tools over SSE.

--- a/scripts/mcp_server.cmd
+++ b/scripts/mcp_server.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=web,severance
-
-call .\support\agent.bat
-
-endlocal

--- a/scripts/mcp_server.sh
+++ b/scripts/mcp_server.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=..
-export SPRING_PROFILES_ACTIVE=web,severance
-
-./support/agent.sh

--- a/scripts/shell_docker.cmd
+++ b/scripts/shell_docker.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
-
-call .\support\agent.bat
-
-endlocal

--- a/scripts/shell_docker.sh
+++ b/scripts/shell_docker.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=..
-export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
-
-./support/agent.sh

--- a/src/main/java/com/embabel/template/ProjectNameApplication.java
+++ b/src/main/java/com/embabel/template/ProjectNameApplication.java
@@ -17,8 +17,12 @@ package com.embabel.template;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.embabel.agent.config.annotation.EnableAgentShell;
+import com.embabel.agent.config.annotation.LoggingTheme;
+
 
 @SpringBootApplication
+@EnableAgentShell(loggingTheme=LoggingTheme.STARWARS)
 class ProjectNameApplication {
     public static void main(String[] args) {
         SpringApplication.run(ProjectNameApplication.class, args);


### PR DESCRIPTION
This pull request removes unused scripts and updates the main application class to enable a specific feature with a custom logging theme. The most important changes include the deletion of several shell and batch scripts and the addition of annotations to the `ProjectNameApplication` class.

### Removal of unused scripts:

I think, we should have separate template for MCP Server and not collocate with Shell.

* Deleted `mcp_server.sh` and `mcp_server.cmd` scripts, which were previously used to run an MCP server. [[1]](diffhunk://#diff-47488c16001346e97fbc7d47000f222412aa321569fbdfe34b73bc1faa5cfc1bL1-L9) [[2]](diffhunk://#diff-b5a837ca191bcd31a373db5550af8641162ffb812f996d25840b7528c8ba6ceaL1-L6)
* Deleted `shell_docker.sh` and `shell_docker.cmd` scripts, which were previously used to run the application in a Dockerized shell environment. [[1]](diffhunk://#diff-cf015dc87b6b5ce736e7f5a1b4a5b3344bc3e465bef5569d18ad62ca98844acaL1-L9) [[2]](diffhunk://#diff-8b7456400a71b193acda2dd7396d0bfbd7a17671bd30238995c81163585f4261L1-L6)

### Updates to the main application class:

* Added `@EnableAgentShell` annotation with a `loggingTheme` parameter set to `LoggingTheme.STARWARS` in `ProjectNameApplication.java` to enable the agent shell feature with a Star Wars-themed logging style.