### PR TITLE
Remove SPRING_ACTIVE_PROFILE variable. Not required.

### DIFF
--- a/scripts/shell.cmd
+++ b/scripts/shell.cmd
@@ -2,7 +2,6 @@
 setlocal
 
 set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=shell,severance
 
 call .\support\agent.bat
 


### PR DESCRIPTION
This pull request includes a small change to the `scripts/shell.cmd` file. The change removes the `SPRING_PROFILES_ACTIVE` environment variable, which was previously set to `shell,severance`.