### PR TITLE
Make shell.sh invocable from the root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Illustrates:
 Run the shell script to start Embabel under Spring Shell:
 
 ```bash
-cd scripts
-./shell.sh
+./scripts/shell.sh
 ```
 
 There is a single example agent, `WriteAndReviewAgent`.

--- a/scripts/shell.cmd
+++ b/scripts/shell.cmd
@@ -1,8 +1,9 @@
 @echo off
 setlocal
 
-set AGENT_APPLICATION=..
+set "script_dir=%~dp0"
+set AGENT_APPLICATION=%script_dir%.."
 
-call .\support\agent.bat
+call "%script_dir%support\agent.bat"
 
 endlocal

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-export AGENT_APPLICATION=..
+script_dir=$(dirname "$0")
+
+export AGENT_APPLICATION="${script_dir}/.."
 
 #export MAVEN_PROFILE=enable-mcp
 
-./support/check_env.sh || exit 1
+"$script_dir/support/check_env.sh" || exit 1
 
-cd ..
+cd "$AGENT_APPLICATION"
 mvn -Dmaven.test.skip=true spring-boot:run


### PR DESCRIPTION
Currently, developers must switch to the scripts directory before invoking shell.sh, which is one extra command. Also, calling ./scripts/shell.sh fails due to the assumption that it is run in the scripts directory.

This change makes shell.sh/bat robust against the invoking directory.