### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,16 @@
 
     <repositories>
         <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>     
+        <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>


### PR DESCRIPTION
This pull request makes a small configuration change to the Maven project by adding a new repository for release dependencies.

- Added the `embabel-releases` Maven repository to the `pom.xml` file to allow fetching release artifacts from `https://repo.embabel.com/artifactory/libs-release`.