### PR TITLE
Enhance CI with build notification workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -U -B test verify
+
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit
+
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
Add notification steps for build success 
This pull request adds automated notification steps to the GitHub Actions workflow for Maven builds. Specifically, it introduces notifications for both build failures and recoveries on the `main` branch, helping the team stay informed about the health of the main build.

**Notification enhancements:**

* Added a `notify` job to trigger a Discord notification workflow when the build fails on the `main` branch. (`.github/workflows/maven.yml`, [.github/workflows/maven.ymlR38-R51](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R38-R51))
* Added a `notify-recovery` job to trigger a recovery notification workflow when the build succeeds on the `main` branch, indicating the build has recovered. (`.github/workflows/maven.yml`, [.github/workflows/maven.ymlR38-R51](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R38-R51))nd failure.