### PR TITLE
Upgrade embabel framework version and spring-boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.13</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- Lookup parent from repository -->
     </parent>
     <groupId>com.embabel.template</groupId>
@@ -18,7 +18,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <embabel-agent.version>0.3.5</embabel-agent.version>
+        <embabel-agent.version>0.5.0</embabel-agent.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Just upgrade embabel framework version to match latest, 0.5.0, as of July 2026.
Updated the spring-boot version to the latest patch release at this time.

No code changes, as default template works just fine.
